### PR TITLE
Force LF endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
# Summary

This prevents line endings being converted from LF to CRLF when the repo is cloned on Windows. This has two benefits:
1) Prevents tons of zero-width invisible changes when a Windows user commits code to the repo
2) Fixes Prettier on Windows