### PR TITLE
Add templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: "\U0001F41E Bug report"
+description: Report an issue with Flatbread
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a repo or REPL that can reproduce the problem you ran into. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided within a reasonable time-frame, the issue will be closed.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: 'Please include browser console / server logs around the time this bug occurred. Optional if provided reproduction. Please try not to insert an image, but copy paste the log text.'
+      render: shell
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: Output of `npx envinfo --system --npmPackages '{flatbread,@flatbread/*}' --binaries --browsers`
+      render: shell
+      placeholder: System, Binaries, Browsers
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Select the severity of this issue
+      options:
+        - annoyance
+        - blocking an upgrade
+        - blocking all usage of Flatbread
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Slack channel
+    url: https://join.slack.com/t/flatbreadworkspace/shared_invite/zt-1bvnhr38j-oHFun85aGfaNp9qwizOORw
+    about: Ask questions and discuss with other Flatbread users in real time.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: 'Feature Request'
+description: Request a new Flatbread feature
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request this feature! If your feature request is complex or substantial enough to warrant in-depth discussion, maintainers may close the issue and ask you to open a [discussion](https://github.com/FlatbreadLabs/flatbread/discussions/categories/ideas).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      description: Please provide a clear and concise description the problem this feature would solve. The more information you can provide here, the better.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the proposed solution
+      description: Please provide a clear and concise description of what you would like to happen.
+      placeholder: I would like to see...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: "Please provide a clear and concise description of any alternative solutions or features you've considered."
+    validations:
+      required: true
+  - type: dropdown
+    id: importance
+    attributes:
+      label: Importance
+      description: How important is this feature to you?
+      options:
+        - Nice to have
+        - Would make my life easier
+        - I cannot use Flatbread without it
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,7 +2,7 @@
 
 <!-- This message body should clearly illustrate what problems it solves. -->
 
-Closes # <!-- It's really useful if your PR references an issue where it is discussed ahead of time. If this PR closes any issues, please list them here with a seperate `Closes #<issue-number>` line for each. If there are any related issues that this does not close, list them before the "Closes" prefix. -->
+Closes # <!-- It's really useful if your PR references an issue where it is discussed ahead of time. If this PR closes any issues, please list them here with a seperate `Closes #<issue-number>` line for each. If there are any related issues that this does not close, list them without the "Closes" prefix. -->
 
 ### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -8,7 +8,7 @@ Closes # <!-- It's really useful if your PR references an issue where it is disc
 
 - [ ] I added doc comments to any new public exports, and inline comments to any hard-to-understand areas
 - [ ] My changes generate no new console errors locally
-- [ ] If applicable, include a test that fails without this PR but passes with it
+- [ ] If applicable, try to include a test that fails without this PR but passes with it
 
 ### Tests
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -10,9 +10,6 @@ Closes # <!-- It's really useful if your PR references an issue where it is disc
 - [ ] My changes generate no new console errors locally
 - [ ] If applicable, try to include a test that fails without this PR but passes with it
 
-### Tests
-
-- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
 
 ### Does this introduce any non-backwards compatible changes?
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,26 @@
+**Summary of changes**
+
+<!-- This message body should clearly illustrate what problems it solves. -->
+
+Closes # <!-- It's really useful if your PR references an issue where it is discussed ahead of time. If this PR closes an issue, please list it here. If there are any related issues that this does not close, list them before the "Closes" prefix. -->
+
+### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
+
+- [ ] I added doc comments to any new public exports, and inline comments to any hard-to-understand areas
+- [ ] My changes generate no new console errors locally
+- [ ] If applicable, include a test that fails without this PR but passes with it
+
+### Tests
+
+- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
+
+### Does this introduce any non-backwards compatible changes?
+
+- [ ] Yes
+- [ ] No
+
+### Does this include any user config changes?
+
+- [ ] Yes
+  - [ ] If so, I have updated the relevant areas of documentation
+- [ ] No

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,7 +2,7 @@
 
 <!-- This message body should clearly illustrate what problems it solves. -->
 
-Closes # <!-- It's really useful if your PR references an issue where it is discussed ahead of time. If this PR closes an issue, please list it here. If there are any related issues that this does not close, list them before the "Closes" prefix. -->
+Closes # <!-- It's really useful if your PR references an issue where it is discussed ahead of time. If this PR closes any issues, please list them here with a seperate `Closes #<issue-number>` line for each. If there are any related issues that this does not close, list them before the "Closes" prefix. -->
 
 ### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
 


### PR DESCRIPTION
### Summary
Introduces a set of templates for Github issues and PRs.

Closes #90

Not sure if I'm missing anything or if some areas are too strict. Happy to discuss and get a best-fit solution for us.